### PR TITLE
chartjs fix chart styling

### DIFF
--- a/brain-tag/src/Views/Components/Buttons/index.css
+++ b/brain-tag/src/Views/Components/Buttons/index.css
@@ -5,9 +5,13 @@
     z-index: 900;
     width: 100%;
     margin: 0;
-    min-height: 60px;
+    height: 60px;
     display:flex;
     flex-direction: row;
     align-items: center;
     padding-left: 40px;
+}
+
+.Charts{
+    margin-bottom:60px;
 }

--- a/brain-tag/src/Views/Components/Channels/Plots/RawData.js
+++ b/brain-tag/src/Views/Components/Channels/Plots/RawData.js
@@ -89,11 +89,7 @@ export default class DynamicLineChart extends Component {
 
         // You can get reference to the chart instance as shown below using onRef. 
         // This allows you to access all chart properties and methods
-        return (
-            <div>
-                <Line data={data} options={options} height={60}/>
-            </div>
-        );
+        return (<Line data={data} options={options} height={60}/>);
     }
 }
 

--- a/brain-tag/src/Views/Components/Channels/Plots/RawData.js
+++ b/brain-tag/src/Views/Components/Channels/Plots/RawData.js
@@ -80,6 +80,7 @@ export default class DynamicLineChart extends Component {
                 backgroundColor: '#00f',
                 borderColor: '#00f',
                 borderWidth: 1,
+                pointRadius: 0,
                 fill: false,
                 data: dps.map((x) => x.y),
                 lineTension: 0
@@ -90,7 +91,7 @@ export default class DynamicLineChart extends Component {
         // This allows you to access all chart properties and methods
         return (
             <div>
-                <Line data={data} options={options} height={70}/>
+                <Line data={data} options={options} height={60}/>
             </div>
         );
     }

--- a/brain-tag/src/Views/Components/Channels/index.css
+++ b/brain-tag/src/Views/Components/Channels/index.css
@@ -13,6 +13,8 @@
     margin: 0 auto;
     align-items: center;
     font-size: 2em;
+    margin-top: 40px;
+    margin-bottom: 40px;
 }
 
 
@@ -33,5 +35,5 @@
 
 canvas {
     width: 100%;
-    height: 100%;
+    height: 100%; 
 }

--- a/brain-tag/src/Views/Components/Channels/index.css
+++ b/brain-tag/src/Views/Components/Channels/index.css
@@ -13,8 +13,6 @@
     margin: 0 auto;
     align-items: center;
     font-size: 2em;
-    margin-top: 40px;
-    margin-bottom: 40px;
 }
 
 


### PR DESCRIPTION
The spacing between the charts should be consistent across monitors now, but please check for yourself before merging. Also the raw data chart has no more dots.

I checked the old code the PSD, and it was also using floating point values generated by parsePowerPSD, so as far as I'm concerned at the moment, it's not something this merge should be addressing. We can ask Rachel about this later.

If there are any problems, please do not merge. I can fix them on this branch first before merging. This results in fewer pull requests and a cleaner tree. 